### PR TITLE
Remove the deeplink from journeys

### DIFF
--- a/standard-covoiturage_openapi.yaml
+++ b/standard-covoiturage_openapi.yaml
@@ -316,8 +316,6 @@ components:
           $ref: '#/components/schemas/Price'
         preferences:
           $ref: '#/components/schemas/Preferences'
-        deepLink:
-          $ref: '#/components/schemas/DeepLink'
 
     DriverJourney:
       allOf:
@@ -476,29 +474,3 @@ components:
           type: string
           description: Brand of the car.
 
-    DeepLink:
-      type: object
-      description: Platform specific deep-link configurations.
-      properties:
-        android:
-          type: object
-          properties:
-            uri:
-              type: string
-              description: |-
-                URI compliant with Android conventions to open the webservice
-                provider mobile app on the screen presenting the specific journey
-                (see [this guide](https://blog.branch.io/technical-guide-to-deep-linking-on-android-chrome-intents/) for more details).
-            storeUrl:
-              type: string
-              description: |-
-                URL of the webservice provider mobile app on the PlayStore
-                in case the app is not yet installed on the device.
-        ios:
-          type: object
-          properties:
-            universalLink:
-              type: string
-              description: |-
-                URI compliant with iOS conventions to open the webservice
-                provider mobile app on the screen presenting the specific journey.

--- a/standard-covoiturage_openapi.yaml
+++ b/standard-covoiturage_openapi.yaml
@@ -268,7 +268,7 @@ components:
           description: Carpooling duration in seconds.
         webUrl:
           type: string
-          description: URL of the journey on the webservice provider platform.
+          description: URL of the journey on the operator platform.
         type:
           type: string
           description: |-


### PR DESCRIPTION
As discussed today and exposed in the [main WIP specification](https://github.com/fabmob/standard-covoiturage/pull/2/files#r832663218), the `deeplink` structure is here to provide a deep linking experience ~1% of the Android users. 

Removing it will greatly simplify this specification and subsequent usages as everything will fit in the `webUrl` (ex: https://github.com/fabmob/standard-covoiturage/pull/4). Let's remove it :)

_Note: the ~1% Android users can still be supported by the operator by providing a web UX to display journeys._

