### PR TITLE
Specification proposal for search workflow

### DIFF
--- a/standard-covoiturage_specification.md
+++ b/standard-covoiturage_specification.md
@@ -39,11 +39,111 @@ The first draft versions of this specification do not include normative parts.
 
 #### 3.1.1. Search for Journeys
 
-TODO explain driver/passenger journeys and link to OpenAPI spec
+##### General Workflow
 
-#### 3.1.2. Search for Regular trips and associated journeys
+There are two flavours of searches: a driver can search for passengers (so, he 
+searches `passenger_journey`), or a passenger can search for a driver (looking 
+for a `driver_journey`). The difference between these two searches are in the 
+endpoints used and the return values, so the following sequence diagram works 
+for both.
 
-TODO explain driver/passenger regular trips and link to OpenAPI spec
+~~~mermaid
+sequenceDiagram
+    participant U as User
+    participant M as MaaS
+    participant T as TO
+    U->>M: Search for trips
+    M->>T: GET /driver_journeys (or /passenger_journeys)
+    T-->>M: DriverJourneys[] (or PassengerJourneys[])
+    M-->>U: Show results
+~~~
+
+The search results are queried by the MaaS platform to the transport operator 
+in a single API call, providing all relevant query informations. The minimum 
+required information is the starting and arrival places.  
+
+In particular, no user information is required to perform a search.
+
+###### The case of a round trip
+
+If the case of a round trip, it is up to the MaaS platform to perform the 
+searches for the outward and return journey separately.
+
+##### The case of regular journeys
+
+Searching for regular journeys has its own specific workflow presented in 
+{TODO anchor link}.
+
+##### Simple search technical specification
+
+The transport operator MUST return at most `count` matching results, or all 
+matching results if `count` parameter is not specified. All returned results 
+MUST match the query parameters.
+
+If the parameter `count` is specified, the transport operator SHOULD return in 
+priority the most relevant results. The measure of relevance is left to the 
+discretion of the transport operator.
+
+If no `departureDate` attribute is provided by the MaaS platform in the call 
+to `GET \driver_journeys` or `GET \passenger_journeys`, the current datetime 
+MUST be assumed.
+
+The `id` attribute of the response MUST be unique for a given Transport 
+Operator, among all journeys (`passengerJourneys` and `driverJourneys`).
+
+The `price` attribute of the response SHOULD be a price estimation, if no 
+estimation is possible, a price with type "UNKNOWN" SHOULD be returned.
+
+#### Search for Regular trips and associated journeys
+
+##### General workflow 
+
+The counterpart of `\passenger_journeys` and `\driver_journeys` endpoints for 
+searching regular journeys are two GET endpoints: `\driver_regular_trips` and 
+`\passenger_regular_trips`. The query parameters specify an additionnal 
+required `departureTimeOfDay`, and an optional `departureWeekdays`.
+
+The return values are similar, they differ mainly in that they offer a 
+`schedules` attribute that details several trips.  More differences will occur 
+at the booking phase.
+
+##### Workflow for more sophisticated regular journeys
+
+It is up to the MaaS platform to assemble the results of several calls into a 
+more sophisticated regular journey. For instance, a varying 
+`departureTimeOfDay` (in the same week, or alterning weeks) can be queried 
+with a large `timeDelta` and post-filtering, or with several calls with 
+`departureTimeOfDay` and concatenation.
+
+##### Technical specification for searching for regular journeys
+
+The transport operator MUST return at most `count` matching results, or all 
+matching results if `count` parameter is not specified. All returned results 
+MUST match the query parameters.
+
+The returned results MAY not reach the `maxDepartureDate` depending on the 
+forecasting horizon of the transport operator.
+
+A regular trip matches the `departureWeekdays` and `departureTimeOfDay` if 
+*any* journey of the regular trip matches the time and day constraint.
+
+The `webUrl` attribute in the response SHOULD link to a page giving an 
+overview of the regular trips (e.g. a "driver" page) and allowing to continue 
+the process of booking regular trips by the user (booking by deeplink).
+
+The transport operator MUST return at most `count` matching results, or all 
+matching results if `count` parameter is not specified. All returned results 
+MUST match the query parameters.
+
+The returned results MAY not reach the `maxDepartureDate` depending on the 
+forecasting horizon of the transport operator.
+
+A regular trip matches the `departureWeekdays` and `departureTimeOfDay` if 
+*any* journey of the regular trip matches the time and day constraint.
+
+The `webUrl` attribute in the response SHOULD link to a page giving an 
+overview of the regular trips (e.g. a "driver" page) and allowing to continue 
+the process of booking regular trips by the user (booking by deeplink).
 
 ### 3.2. Booking
 


### PR DESCRIPTION
DRAFT
This is a proposal of specifications for the search of a single journey or of regular trips. 

Mermaid diagrams are rendered by Github, so you can view the file [directly on Github](https://github.com/fabmob/standard-covoiturage/blob/spec_search/standard-covoiturage_specification.md)