### PR TITLE
Small improvements propositions on the search API

### DIFF
--- a/standard-covoiturage_openapi.yaml
+++ b/standard-covoiturage_openapi.yaml
@@ -531,13 +531,13 @@ components:
         type:
           type: string
           description: |-
-            Either « FREE » or « PAYING » or « UNKNOWN ».
+            Either « FREE » or « PAYING »
           enum:
           - FREE
           - PAYING
         amount:
           type: number
-          description: Carpooling passenger cost estimate. If `type` is PAYING, a missing amount means that the price cannot be estimated yet.
+          description: Amount expected by the carpooling operator. If `type` is PAYING, a missing amount means that the price cannot be estimated yet.
           format: float
         currency:
           type: string

--- a/standard-covoiturage_openapi.yaml
+++ b/standard-covoiturage_openapi.yaml
@@ -232,7 +232,8 @@ components:
     departureDate:
       name: departureDate
       in: query
-      description: Departure datetime using a UNIX UTC timestamp in seconds. If left out, the current time should be assumed.
+      description: Departure datetime using a UNIX UTC timestamp in seconds.
+      required: true
       schema:
         type: integer
 

--- a/standard-covoiturage_openapi.yaml
+++ b/standard-covoiturage_openapi.yaml
@@ -260,7 +260,7 @@ components:
         type: array
         items:
           type: string
-        default: mon,tue,wed,thu,fri,sat,sun
+        default: MON,TUE,WED,THU,FRI,SAT,SUN
 
     timeDelta:
       name: timeDelta
@@ -507,13 +507,13 @@ components:
           type: string
           description: Day of week of the passenger pick-up.
           enum:
-            - mon
-            - tue
-            - wed
-            - thu
-            - fri
-            - sat
-            - sun
+            - MON
+            - TUE
+            - WED
+            - THU
+            - FRI
+            - SAT
+            - SUN
         passengerPickupTimeOfDay:
           description: |-
             Passenger pick-up time of day represented as

--- a/standard-covoiturage_openapi.yaml
+++ b/standard-covoiturage_openapi.yaml
@@ -532,13 +532,13 @@ components:
         type:
           type: string
           description: |-
-            Either « FREE » or « PAYING »
+            Either « FREE » or « PAYING » or « UNKNOWN ».
           enum:
           - FREE
           - PAYING
         amount:
           type: number
-          description: Amount expected by the carpooling operator. If `type` is PAYING, a missing amount means that the price cannot be estimated yet.
+          description: Carpooling passenger cost estimate. If `type` is PAYING, a missing amount means that the price cannot be estimated yet.
           format: float
         currency:
           type: string

--- a/standard-covoiturage_openapi.yaml
+++ b/standard-covoiturage_openapi.yaml
@@ -532,15 +532,13 @@ components:
         type:
           type: string
           description: |-
-            Either « FREE », « PAYING » or « UNKNOWN ». « UNKNOWN » is given
-            when it should be « PAYING » but we cannot set the price yet.
+            Either « FREE » or « PAYING ».
           enum:
           - FREE
           - PAYING
-          - UNKNOWN
         amount:
           type: number
-          description: Carpooling passenger cost.
+          description: Carpooling passenger cost estimate. If `type` is PAYING, a missing amount means that the price cannot be estimated yet.
           format: float
         currency:
           type: string

--- a/standard-covoiturage_openapi.yaml
+++ b/standard-covoiturage_openapi.yaml
@@ -532,13 +532,19 @@ components:
         type:
           type: string
           description: |-
+<<<<<<< HEAD
             Either « FREE » or « PAYING » or « UNKNOWN ».
+=======
+            Either « FREE », « PAYING » or « UNKNOWN ». « UNKNOWN » is given
+            when it should be « PAYING » but we cannot set the price yet.
+>>>>>>> parent of 71d5e37... Remove "UNKNOWN" modality
           enum:
           - FREE
           - PAYING
+          - UNKNOWN
         amount:
           type: number
-          description: Carpooling passenger cost estimate. If `type` is PAYING, a missing amount means that the price cannot be estimated yet.
+          description: Carpooling passenger cost.
           format: float
         currency:
           type: string

--- a/standard-covoiturage_openapi.yaml
+++ b/standard-covoiturage_openapi.yaml
@@ -26,7 +26,7 @@ paths:
         - $ref: '#/components/parameters/departureLng'
         - $ref: '#/components/parameters/arrivalLat'
         - $ref: '#/components/parameters/arrivalLng'
-        - $ref: '#/components/parameters/departureTime'
+        - $ref: '#/components/parameters/departureDate'
         - $ref: '#/components/parameters/timeDelta'
         - $ref: '#/components/parameters/departureRadius'
         - $ref: '#/components/parameters/arrivalRadius'
@@ -62,7 +62,7 @@ paths:
         - $ref: '#/components/parameters/departureLng'
         - $ref: '#/components/parameters/arrivalLat'
         - $ref: '#/components/parameters/arrivalLng'
-        - $ref: '#/components/parameters/departureTime'
+        - $ref: '#/components/parameters/departureDate'
         - $ref: '#/components/parameters/timeDelta'
         - $ref: '#/components/parameters/departureRadius'
         - $ref: '#/components/parameters/arrivalRadius'
@@ -229,8 +229,8 @@ components:
       schema:
         type: number
 
-    departureTime:
-      name: departureTime
+    departureDate:
+      name: departureDate
       in: query
       description: Departure datetime using a UNIX UTC timestamp in seconds. If left out, the current time should be assumed.
       schema:
@@ -444,7 +444,7 @@ components:
     JourneySchedule:
       type: object
       required:
-        - passengerPickupTime
+        - passengerPickupDate
         - type
       properties:
         id:
@@ -452,12 +452,12 @@ components:
           minLength: 1
           maxLength: 255
           description: Journey's id. It MUST be unique for a given operator.
-        passengerPickupTime:
+        passengerPickupDate:
           type: number
           description: |-
             Passenger pickup datetime as a UNIX UTC timestamp in seconds.
           format: long
-        driverDepartureTime:
+        driverDepartureDate:
           type: number
           description: |-
             Driver departure datetime as a UNIX UTC timestamp in seconds.
@@ -494,7 +494,7 @@ components:
         - $ref: '#/components/schemas/JourneySchedule'
         - type: object
           required:
-            - driverDepartureTime
+            - driverDepartureDate
           properties:
             requestedSeats:
               type: integer

--- a/standard-covoiturage_openapi.yaml
+++ b/standard-covoiturage_openapi.yaml
@@ -532,19 +532,15 @@ components:
         type:
           type: string
           description: |-
-<<<<<<< HEAD
-            Either « FREE » or « PAYING » or « UNKNOWN ».
-=======
             Either « FREE », « PAYING » or « UNKNOWN ». « UNKNOWN » is given
             when it should be « PAYING » but we cannot set the price yet.
->>>>>>> parent of 71d5e37... Remove "UNKNOWN" modality
           enum:
           - FREE
           - PAYING
           - UNKNOWN
         amount:
           type: number
-          description: Carpooling passenger cost.
+          description: Carpooling passenger cost estimate. In the case of integrated booking by API, amount expected by the carpooling operator.
           format: float
         currency:
           type: string

--- a/standard-covoiturage_openapi.yaml
+++ b/standard-covoiturage_openapi.yaml
@@ -26,7 +26,7 @@ paths:
         - $ref: '#/components/parameters/departureLng'
         - $ref: '#/components/parameters/arrivalLat'
         - $ref: '#/components/parameters/arrivalLng'
-        - $ref: '#/components/parameters/departureDate'
+        - $ref: '#/components/parameters/departureTime'
         - $ref: '#/components/parameters/timeDelta'
         - $ref: '#/components/parameters/departureRadius'
         - $ref: '#/components/parameters/arrivalRadius'
@@ -62,7 +62,7 @@ paths:
         - $ref: '#/components/parameters/departureLng'
         - $ref: '#/components/parameters/arrivalLat'
         - $ref: '#/components/parameters/arrivalLng'
-        - $ref: '#/components/parameters/departureDate'
+        - $ref: '#/components/parameters/departureTime'
         - $ref: '#/components/parameters/timeDelta'
         - $ref: '#/components/parameters/departureRadius'
         - $ref: '#/components/parameters/arrivalRadius'
@@ -229,8 +229,8 @@ components:
       schema:
         type: number
 
-    departureDate:
-      name: departureDate
+    departureTime:
+      name: departureTime
       in: query
       description: Departure datetime using a UNIX UTC timestamp in seconds.
       schema:
@@ -444,7 +444,7 @@ components:
     JourneySchedule:
       type: object
       required:
-        - passengerPickupDate
+        - passengerPickupTime
         - type
         - webUrl
       properties:
@@ -453,12 +453,12 @@ components:
           minLength: 1
           maxLength: 255
           description: Journey's id. It MUST be unique for a given operator.
-        passengerPickupDate:
+        passengerPickupTime:
           type: number
           description: |-
             Passenger pickup datetime as a UNIX UTC timestamp in seconds.
           format: long
-        driverDepartureDate:
+        driverDepartureTime:
           type: number
           description: |-
             Driver departure datetime as a UNIX UTC timestamp in seconds.
@@ -495,7 +495,7 @@ components:
         - $ref: '#/components/schemas/JourneySchedule'
         - type: object
           required:
-            - driverDepartureDate
+            - driverDepartureTime
           properties:
             requestedSeats:
               type: integer

--- a/standard-covoiturage_openapi.yaml
+++ b/standard-covoiturage_openapi.yaml
@@ -446,7 +446,6 @@ components:
       required:
         - passengerPickupTime
         - type
-        - webUrl
       properties:
         id:
           type: string
@@ -465,7 +464,7 @@ components:
           format: long
         webUrl:
           type: string
-          description: URL of the journey on the webservice provider platform.
+          description: URL of the journey on the webservice provider platform. Required to support booking by deeplink.
         type:
           type: string
           description: |-
@@ -532,7 +531,7 @@ components:
         type:
           type: string
           description: |-
-            Either « FREE » or « PAYING ».
+            Either « FREE » or « PAYING » or « UNKNOWN ».
           enum:
           - FREE
           - PAYING

--- a/standard-covoiturage_openapi.yaml
+++ b/standard-covoiturage_openapi.yaml
@@ -232,7 +232,7 @@ components:
     departureTime:
       name: departureTime
       in: query
-      description: Departure datetime using a UNIX UTC timestamp in seconds.
+      description: Departure datetime using a UNIX UTC timestamp in seconds. If left out, the current time should be assumed.
       schema:
         type: integer
 


### PR DESCRIPTION
This PR will list some propositions I have concerning the search workflow. I try to isolate each proposition into a single commit to make it easy to review and revert if you do not agree. 

1. I propose to change some attribute names with datetimes. I think `Time` gives a more accurate hint of the type than `Date` (e.g. `departureTime` instead of `departureDate`, and is more consistent with the `timeDelta` attribute. I did not change `{min,max}DepartureDate`, despite also being datetimes  as in practice the date will matter more than the time (from my understanding). Should we change the type here or is it nitpicking?

2. As `departureDate` (or `departureTime`) is an optional parameter, I specified the behavior if omitted in the parameter description.

3. The price type enum "FREE", "PAYING", "UNKNOWN" is not really self-explanatory. I propose to remove "UNKNOWN", which can be guessed if type is "PAYING" but no amount is specified (optional field). I also mentioned that it is an *estimate*.

4. If I refer to the (unmerged) [specification document](https://github.com/fabmob/standard-covoiturage/blob/5350ba7895d31540bca919158e2c1e81a3b8f903/standard-covoiturage_specification.md) I read "MaaS platforms and carpooling operators MUST support at least one of these 2 flows [deeplink or API] if they implement booking.". If everyone agree with this, I suggest to remove webUrl as a *required* parameter as it is not necessarily needed if only booking by API is available (I updated the description to notice that it is required to support booking by deeplink).

5. For consistency with other enumerations, I suggest to put the `passengerPickupDay` enum options all uppercase.

6. I find the vocabulary "driverJourney" and "passengerJourney" confusing. I also wonder if there is a semantic difference between "Journey" and "Trip". I haven't made any change on this, opened an issue instead (#24).