### PR TITLE
WIP: integrated booking by API

### DIFF
--- a/standard-covoiturage_openapi.yaml
+++ b/standard-covoiturage_openapi.yaml
@@ -1025,7 +1025,8 @@ components:
 
     bookingId:
       type: string
-      description: Booking id is common between both operators, and must be set as a MD5 hashing of a string concatenating the `driverJourneyId`, the `passengerJourneyId` and a UNIX UTC timestamp in seconds.
+      format: uuid
+      description: Booking id is common between both operators, and must be created as a UUID by whoever initiates the booking.
 
     bookingStatus:
       type: string

--- a/standard-covoiturage_openapi.yaml
+++ b/standard-covoiturage_openapi.yaml
@@ -309,6 +309,13 @@ paths:
         required: true
         schema:
           $ref: '#/components/schemas/bookingStatus'
+      - name: message
+        description: Free text content of a message. The message can contain explanations on the status change.
+        in: query
+        schema:
+          type: string
+          maxLength: 500
+
       responses:
         200:
           description: Successful operation.

--- a/standard-covoiturage_openapi.yaml
+++ b/standard-covoiturage_openapi.yaml
@@ -223,6 +223,10 @@ paths:
                 - message
                 - recipientCarpoolerType
               properties:
+                from:
+                  $ref: '#/components/schemas/User'
+                to:
+                  $ref: '#/components/schemas/User'
                 message:
                   type: string
                   maxLength: 500

--- a/standard-covoiturage_openapi.yaml
+++ b/standard-covoiturage_openapi.yaml
@@ -933,6 +933,11 @@ components:
         - id
         - status
         - price
+        - passengerPickupDate
+        - passengerPickupLat
+        - passengerPickupLng
+        - passengerDropLat
+        - passengerDropLng
       properties:
         id:
           $ref: '#/components/schemas/bookingId'

--- a/standard-covoiturage_openapi.yaml
+++ b/standard-covoiturage_openapi.yaml
@@ -224,9 +224,9 @@ paths:
                 - recipientCarpoolerType
               properties:
                 from:
-                  $ref: '#/components/schemas/UserId'
+                  $ref: '#/components/schemas/User'
                 to:
-                  $ref: '#/components/schemas/UserId'
+                  $ref: '#/components/schemas/User'
                 message:
                   type: string
                   maxLength: 500
@@ -868,10 +868,21 @@ components:
           description: ISO 4217 code representing the currency of the price.
 
     User:
-      allOf:
-        - $ref: '#/components/schemas/UserId'
       type: object
+      required:
+        - id
+        - alias
+        - operator
       properties:
+        id:
+          type: string
+          description: User's identifier. It MUST be unique for a given `operator`.
+        operator:
+          type: string
+          description: The operator identifier. MUST be a Fully Qualified Domain Name (example carpool.mycity.com) owned by the operator or a Partially Qualified Domain Name (example operator.org) owned and exclusively operated by the operator. Operators SHOULD always send the same value.
+        alias:
+          type: string
+          description: User's alias.
         firstName:
           type: string
           description: User's first name.
@@ -897,22 +908,6 @@ components:
           type: boolean
           description: true if the identity of this user has been verified by the operator or a third party; and the firstName, lastName, birthdate have been confirmed as identitical to an official identity proof document. Can be left empty if the information is not available.
 
-    UserId:
-      type: object
-      required:
-        - id
-        - alias
-        - operator
-      properties:
-        id:
-          type: string
-          description: User's identifier. It MUST be unique for a given `operator`
-        operator:
-          type: string
-          description: The operator identifier. MUST be a Fully Qualified Domain Name (example carpool.mycity.com) owned by the operator or a Partially Qualified Domain Name (example operator.org) owned and exclusively operated by the operator. Operators SHOULD always send the same value.
-        alias:
-          type: string
-          description: User's alias
 
     Preferences:
       type: object
@@ -969,9 +964,9 @@ components:
         id:
           $ref: '#/components/schemas/bookingId'
         driver:
-          $ref: '#/components/schemas/UserId'
+          $ref: '#/components/schemas/User'
         passenger:
-          $ref: '#/components/schemas/UserId'
+          $ref: '#/components/schemas/User'
         passengerPickupDate:
           type: number
           description: Passenger pickup datetime as a UNIX UTC timestamp in seconds.

--- a/standard-covoiturage_openapi.yaml
+++ b/standard-covoiturage_openapi.yaml
@@ -1014,6 +1014,11 @@ components:
           $ref: '#/components/schemas/Price'
         car:
           $ref: '#/components/schemas/Car'
+        journeyId:
+          type: string
+          minLength: 1
+          maxLength: 255
+          description: ID of the journey to which the booking is related (if any)
         message:
           type: string
           maxLength: 500

--- a/standard-covoiturage_openapi.yaml
+++ b/standard-covoiturage_openapi.yaml
@@ -1001,7 +1001,7 @@ components:
         distance:
           type: integer
           description: |
-            Carpooling distance in meters. When the booking is COMPLETED or VALIDATED, this is the actual distance travelled if available.
+            Carpooling distance in meters.
         webUrl:
           type: string
           description: URL of the booking on the webservice provider platform.

--- a/standard-covoiturage_openapi.yaml
+++ b/standard-covoiturage_openapi.yaml
@@ -1021,7 +1021,7 @@ components:
           type: string
           minLength: 1
           maxLength: 255
-          description: ID of the journey to which the booking is related (if any). Unique given the `User`'s `operator` property.
+          description: ID of the Passenger's journey to which the booking is related (if any). Unique given the `User`'s `operator` property.
 
     bookingId:
       type: string

--- a/standard-covoiturage_openapi.yaml
+++ b/standard-covoiturage_openapi.yaml
@@ -1014,10 +1014,6 @@ components:
           minLength: 1
           maxLength: 255
           description: ID of the journey to which the booking is related (if any)
-        message:
-          type: string
-          maxLength: 500
-          description: Free text content of a message.
 
     bookingId:
       type: string

--- a/standard-covoiturage_openapi.yaml
+++ b/standard-covoiturage_openapi.yaml
@@ -238,6 +238,15 @@ paths:
                     - passenger
                   default: driver
                   description: Defines if the recipient of this message is either the driver or the passenger.
+                journeyId:
+                  type: string
+                  minLength: 1
+                  maxLength: 255
+                  description: ID of the journey to which the message is related (if any)
+                bookingId:
+                  $ref: '#/components/schemas/bookingId'
+                  description: ID of the booking to which the message is related (if any)
+
       responses:
         201:
           description: Successful operation.

--- a/standard-covoiturage_openapi.yaml
+++ b/standard-covoiturage_openapi.yaml
@@ -238,11 +238,16 @@ paths:
                     - PASSENGER
                   default: DRIVER
                   description: Defines if the recipient of this message is either the driver or the passenger.
-                journeyId:
+                driverJourneyId:
                   type: string
                   minLength: 1
                   maxLength: 255
-                  description: ID of the journey to which the message is related (if any)
+                  description: ID of the Driver's journey to which the message is related (if any). Unique given the `User`'s `operator` property.
+                passengerJourneyId:
+                  type: string
+                  minLength: 1
+                  maxLength: 255
+                  description: ID of the Passenger's journey to which the message is related (if any). Unique given the `User`'s `operator` property.
                 bookingId:
                   allOf:
                     - $ref: '#/components/schemas/bookingId'
@@ -1009,11 +1014,16 @@ components:
           $ref: '#/components/schemas/Price'
         car:
           $ref: '#/components/schemas/Car'
-        journeyId:
+        driverJourneyId:
           type: string
           minLength: 1
           maxLength: 255
-          description: ID of the journey to which the booking is related (if any)
+          description: ID of the Driver's journey to which the booking is related (if any). Unique given the `User`'s `operator` property.
+        passengerJourneyId:
+          type: string
+          minLength: 1
+          maxLength: 255
+          description: ID of the journey to which the booking is related (if any). Unique given the `User`'s `operator` property.
 
     bookingId:
       type: string

--- a/standard-covoiturage_openapi.yaml
+++ b/standard-covoiturage_openapi.yaml
@@ -216,13 +216,17 @@ paths:
         content:
           application/json:
             schema:
-              allOf:
-                - $ref: '#/components/schemas/ConnectionMessage'
               type: object
               required:
+                - from
+                - to
                 - message
                 - recipientCarpoolerType
               properties:
+                message:
+                  type: string
+                  maxLength: 500
+                  description: Free text content of a message. The message can contain all the details (phone number, email, etc.) allowing the recipient to call back the sender in order to carpool with him/her.
                 recipientCarpoolerType:
                   type: string
                   enum:
@@ -917,17 +921,8 @@ components:
           type: string
           description: Brand of the car.
 
-    ConnectionMessage:
-      type: object
-      properties:
-        message:
-          type: string
-          maxLength: 500
-          description: Free text content of a message. The message can contain all the details (phone number, email, etc.) allowing the recipient to call back the sender in order to carpool with him/her.
 
     Booking:
-      allOf:
-        - $ref: '#/components/schemas/ConnectionMessage'
       type: object
       required:
         - id
@@ -983,6 +978,10 @@ components:
           $ref: '#/components/schemas/Price'
         car:
           $ref: '#/components/schemas/Car'
+        message:
+          type: string
+          maxLength: 500
+          description: Free text content of a message. The message can contain all the details (phone number, email, etc.) allowing the recipient to call back the sender in order to carpool with him/her.
 
     bookingId:
       type: string

--- a/standard-covoiturage_openapi.yaml
+++ b/standard-covoiturage_openapi.yaml
@@ -982,7 +982,7 @@ components:
     bookingId:
       type: string
       format: uuid
-      description: Booking id is common between both operators, and must be created as a UUID by whoever initiates the booking.
+      description: Booking id is common between both operators, and must be created as a [UUID](https://datatracker.ietf.org/doc/html/rfc4122) by whoever initiates the booking.  Usage of a [4 UUID](https://datatracker.ietf.org/doc/html/rfc4122#section-4.4) generation algorithm is advised.
 
     bookingStatus:
       type: string

--- a/standard-covoiturage_openapi.yaml
+++ b/standard-covoiturage_openapi.yaml
@@ -249,8 +249,7 @@ paths:
       tags:
       - Interact
       summary: Create a punctual outward Booking request.
-      description: Route used to synchronize a Booking request initiated by a platform to the second platform involved in the shared punctual outward journey. While posting a new Booking, its status shall always be set first as `status=WAITING_CONFIRMATION`. The  Booking MUST be created using the relevant `passengerJourneyId` or `driverJourneyId` attributes according to the operator role handling the request (the operator can recognize its own role thanks to the `driverOperator` and `passengerOperator` attributes).
-        _Reminder:_ In case of booking without deeplink, the sender platform MUST also store the Booking object, and be ready to receive modifications of it through the PATCH /bookings API endpoint.
+      description: Route used to synchronize a Booking request initiated by a platform to the second platform involved in the shared punctual outward journey. While posting a new Booking, its status must always be set first as `status=WAITING_CONFIRMATION`. _Reminder:_ In case of booking without deeplink, the sender platform MUST also store the Booking object, and be ready to receive modifications of it through the PATCH /bookings API endpoint.
       operationId: postBookings
       requestBody:
         content:
@@ -503,24 +502,6 @@ components:
         are returned.
       schema:
         type: integer
-
-    passengerJourneyId:
-      name: passengerJourneyId
-      in: query
-      description: Identifier of the passenger Journey representing the initial context of a search for drivers. If the requester platform aims to monitor in its platform the booking made by its passenger for the Journey, it SHOULD fill this parameter. This id MUST be unique for a given operator.
-      schema:
-        type: string
-        minLength: 1
-        maxLength: 255
-
-    driverJourneyId:
-      name: driverJourneyId
-      in: query
-      description: Identifier of the driver Journey representing the initial context of a search for passengers. If the requester platform aims to monitor in its platform the booking made by its driver for the Journey, it SHOULD fill this parameter. This id MUST be unique for a given operator.
-      schema:
-        type: string
-        minLength: 1
-        maxLength: 255
 
   schemas:
     Trip:
@@ -938,20 +919,7 @@ components:
 
     ConnectionMessage:
       type: object
-      required:
-        - driverJourneyId
-        - passengerJourneyId
       properties:
-        driverJourneyId:
-          type: string
-          minLength: 1
-          maxLength: 255
-          description: Driver Journey's id. It MUST be unique for a given operator.
-        passengerJourneyId:
-          type: string
-          minLength: 1
-          maxLength: 255
-          description: Passenger Journey's id. It MUST be unique for a given operator.
         message:
           type: string
           maxLength: 500

--- a/standard-covoiturage_openapi.yaml
+++ b/standard-covoiturage_openapi.yaml
@@ -1,4 +1,5 @@
 openapi: 3.0.1
+
 info:
   title: ""
   description: ""
@@ -6,6 +7,7 @@ info:
   license:
     name: Apache 2.0
     url: http://www.apache.org/licenses/LICENSE-2.0.html
+
 tags:
   - name: Search
     description: API routes to search for journeys. These routes can be left opened to public.
@@ -413,9 +415,7 @@ paths:
 # Schemas
 #
 components:
-
   parameters:
-
     departureLat:
       name: departureLat
       in: query
@@ -913,7 +913,6 @@ components:
           type: boolean
           description: true if the identity of this user has been verified by the operator or a third party; and the firstName, lastName, birthdate have been confirmed as identitical to an official identity proof document. Can be left empty if the information is not available.
 
-
     Preferences:
       type: object
       properties:
@@ -950,7 +949,6 @@ components:
         brand:
           type: string
           description: Brand of the car.
-
 
     Booking:
       type: object

--- a/standard-covoiturage_openapi.yaml
+++ b/standard-covoiturage_openapi.yaml
@@ -924,18 +924,6 @@ components:
           type: string
           maxLength: 500
           description: Free text content of a message. The message can contain all the details (phone number, email, etc.) allowing the recipient to call back the sender in order to carpool with him/her.
-        driverOperator:
-          type: string
-          description: Name of the operator owning the DriverJourney.
-        driverOperatorWebUrl:
-          type: string
-          description: Url on the website of the operator owning the DriverJourney.
-        passengerOperator:
-          type: string
-          description: Name of the operator owning the PassengerJourney.
-        passengerOperatorWebUrl:
-          type: string
-          description: Url on the website of the operator owning the PassengerJourney.
 
     Booking:
       allOf:

--- a/standard-covoiturage_openapi.yaml
+++ b/standard-covoiturage_openapi.yaml
@@ -864,10 +864,14 @@ components:
       required:
         - id
         - alias
+        - operatorWebUrl
       properties:
         id:
           type: string
-          description: User's unique identifier.
+          description: User's identifier. It MUST be unique for a given `operatorWebUrl`.
+        operatorWebUrl:
+          type: string
+          description: Base URL of the website of the operator owning the DriverJourney.
         alias:
           type: string
           description: User's alias.

--- a/standard-covoiturage_openapi.yaml
+++ b/standard-covoiturage_openapi.yaml
@@ -1022,7 +1022,7 @@ components:
         message:
           type: string
           maxLength: 500
-          description: Free text content of a message. The message can contain all the details (phone number, email, etc.) allowing the recipient to call back the sender in order to carpool with him/her.
+          description: Free text content of a message.
 
     bookingId:
       type: string

--- a/standard-covoiturage_openapi.yaml
+++ b/standard-covoiturage_openapi.yaml
@@ -275,47 +275,6 @@ paths:
           $ref: '#/components/responses/InternalServerError'
 
   /bookings/{bookingId}:
-    put:
-      tags:
-      - Interact
-      summary: Update a punctual outward Booking request.
-      description: Route used to update a Booking request made by a platform through deeplinking to the platform having initiated the Book (e.g. the MaaS platform). In order to avoid unsynchronized data, a pair of platforms handling a shared booking initiated without deeplinking SHOULD NOT used this API endpoint but only the PATCH /bookings one.
-      operationId: putBookings
-      parameters:
-      - name: bookingId
-        in: path
-        required: true
-        schema:
-          $ref: '#/components/schemas/bookingId'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Booking'
-
-      responses:
-        200:
-          description: Successful operation. The Booking has been updated.
-        400:
-          $ref: '#/components/responses/BadRequest'
-        401:
-          $ref: '#/components/responses/Unauthorized'
-        429:
-          $ref: '#/components/responses/TooManyRequests'
-        500:
-          $ref: '#/components/responses/InternalServerError'
-        404:
-          description: The targeted journey, booking or user no more exists.  Error code can be among  `missing_journey, missing_booking, missing_user` .
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    description: |-
-                      Explain why the request couldn't be processed.
-
     patch:
       tags:
       - Interact

--- a/standard-covoiturage_openapi.yaml
+++ b/standard-covoiturage_openapi.yaml
@@ -205,6 +205,209 @@ paths:
         500:
           $ref: '#/components/responses/InternalServerError'
 
+  /messages:
+    post:
+      tags:
+      - Interact
+      summary: Send a message to the owner of a retrieved journey.
+      description: Route used to allow a user to connect back to the owner of a retrieved journey through a texte message.
+      operationId: postConnections
+      requestBody:
+        content:
+          application/json:
+            schema:
+              allOf:
+                - $ref: '#/components/schemas/ConnectionMessage'
+              type: object
+              required:
+                - message
+                - recipientCarpoolerType
+              properties:
+                recipientCarpoolerType:
+                  type: string
+                  enum:
+                    - driver
+                    - passenger
+                  default: driver
+                  description: Defines if the recipient of this message is either the driver or the passenger.
+      responses:
+        201:
+          description: Successful operation.
+        404:
+          description: The targeted journey or user no more exists.
+        400:
+          $ref: '#/components/responses/BadRequest'
+        401:
+          $ref: '#/components/responses/Unauthorized'
+        429:
+          $ref: '#/components/responses/TooManyRequests'
+        500:
+          $ref: '#/components/responses/InternalServerError'
+
+  /bookings:
+    post:
+      tags:
+      - Interact
+      summary: Create a punctual outward Booking request.
+      description: Route used to synchronize a Booking request initiated by a platform to the second platform involved in the shared punctual outward journey. While posting a new Booking, its status shall always be set first as `status=WAITING_CONFIRMATION`. The  Booking MUST be created using the relevant `passengerJourneyId` or `driverJourneyId` attributes according to the operator role handling the request (the operator can recognize its own role thanks to the `driverOperator` and `passengerOperator` attributes).
+        _Reminder:_ In case of booking without deeplink, the sender platform MUST also store the Booking object, and be ready to receive modifications of it through the PATCH /bookings API endpoint.
+      operationId: postBookings
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Booking'
+
+      responses:
+        201:
+          description: Successful operation. A new Booking has been created.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Booking'
+        400:
+          $ref: '#/components/responses/BadRequest'
+        401:
+          $ref: '#/components/responses/Unauthorized'
+        429:
+          $ref: '#/components/responses/TooManyRequests'
+        500:
+          $ref: '#/components/responses/InternalServerError'
+
+  /bookings/{bookingId}:
+    put:
+      tags:
+      - Interact
+      summary: Update a punctual outward Booking request.
+      description: Route used to update a Booking request made by a platform through deeplinking to the platform having initiated the Book (e.g. the MaaS platform). In order to avoid unsynchronized data, a pair of platforms handling a shared booking initiated without deeplinking SHOULD NOT used this API endpoint but only the PATCH /bookings one.
+      operationId: putBookings
+      parameters:
+      - name: bookingId
+        in: path
+        required: true
+        schema:
+          $ref: '#/components/schemas/bookingId'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Booking'
+
+      responses:
+        200:
+          description: Successful operation. The Booking has been updated.
+        400:
+          $ref: '#/components/responses/BadRequest'
+        401:
+          $ref: '#/components/responses/Unauthorized'
+        429:
+          $ref: '#/components/responses/TooManyRequests'
+        500:
+          $ref: '#/components/responses/InternalServerError'
+        404:
+          description: The targeted journey, booking or user no more exists.  Error code can be among  `missing_journey, missing_booking, missing_user` .
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    description: |-
+                      Explain why the request couldn't be processed.
+
+    patch:
+      tags:
+      - Interact
+      summary: Updates status of an existing Booking request.
+      description: Route used to update the status of an existing Booking request. Should be used usually just to confirm, cancel, etc. an existing Booking.
+      operationId: patchBookings
+      parameters:
+      - name: bookingId
+        in: path
+        required: true
+        schema:
+          $ref: '#/components/schemas/bookingId'
+      - name: status
+        description: New status of the Booking.
+        in: query
+        required: true
+        schema:
+          $ref: '#/components/schemas/bookingStatus'
+      responses:
+        200:
+          description: Successful operation.
+        400:
+          $ref: '#/components/responses/BadRequest'
+        401:
+          $ref: '#/components/responses/Unauthorized'
+        429:
+          $ref: '#/components/responses/TooManyRequests'
+        500:
+          $ref: '#/components/responses/InternalServerError'
+        404:
+          description: The targeted journey, booking or user no more exists.  Error code can be among  `missing_journey, missing_booking, missing_user` .
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    description: |-
+                      Explain why the request couldn't be processed.
+        409:
+          description: Conflict. This booking has already the new status requested. Error code is  `status_already_set`.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    description: |-
+                      Explain why the request couldn't be processed.
+
+
+    get:
+      tags:
+      - Interact
+      summary: Retrieves an existing Booking request.
+      description: Route used to retrieve the details of an existing Booking request. Can only be used by the operator having created the Booking request. This route is provided to check if the Booking object state is similar between two operators, but its usage should be required to handle the full use case of a booking.
+      operationId: getBookings
+      parameters:
+      - name: bookingId
+        in: path
+        required: true
+        schema:
+          $ref: '#/components/schemas/bookingId'
+      responses:
+        200:
+          description: Successful operation.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Booking'
+        400:
+          $ref: '#/components/responses/BadRequest'
+        401:
+          $ref: '#/components/responses/Unauthorized'
+        429:
+          $ref: '#/components/responses/TooManyRequests'
+        500:
+          $ref: '#/components/responses/InternalServerError'
+        404:
+          description: This Booking object no more exists. Error code can be among  `missing_journey, missing_booking, missing_user` .
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    description: |-
+                      Explain why the request couldn't be processed.
+
   /status:
     get:
       tags:
@@ -341,6 +544,24 @@ components:
         are returned.
       schema:
         type: integer
+
+    passengerJourneyId:
+      name: passengerJourneyId
+      in: query
+      description: Identifier of the passenger Journey representing the initial context of a search for drivers. If the requester platform aims to monitor in its platform the booking made by its passenger for the Journey, it SHOULD fill this parameter. This id MUST be unique for a given operator.
+      schema:
+        type: string
+        minLength: 1
+        maxLength: 255
+
+    driverJourneyId:
+      name: driverJourneyId
+      in: query
+      description: Identifier of the driver Journey representing the initial context of a search for passengers. If the requester platform aims to monitor in its platform the booking made by its driver for the Journey, it SHOULD fill this parameter. This id MUST be unique for a given operator.
+      schema:
+        type: string
+        minLength: 1
+        maxLength: 255
 
   schemas:
     Trip:
@@ -755,6 +976,108 @@ components:
         brand:
           type: string
           description: Brand of the car.
+
+    ConnectionMessage:
+      type: object
+      required:
+        - driverJourneyId
+        - passengerJourneyId
+      properties:
+        driverJourneyId:
+          type: string
+          minLength: 1
+          maxLength: 255
+          description: Driver Journey's id. It MUST be unique for a given operator.
+        passengerJourneyId:
+          type: string
+          minLength: 1
+          maxLength: 255
+          description: Passenger Journey's id. It MUST be unique for a given operator.
+        message:
+          type: string
+          maxLength: 500
+          description: Free text content of a message. The message can contain all the details (phone number, email, etc.) allowing the recipient to call back the sender in order to carpool with him/her.
+        driverOperator:
+          type: string
+          description: Name of the operator owning the DriverJourney.
+        driverOperatorWebUrl:
+          type: string
+          description: Url on the website of the operator owning the DriverJourney.
+        passengerOperator:
+          type: string
+          description: Name of the operator owning the PassengerJourney.
+        passengerOperatorWebUrl:
+          type: string
+          description: Url on the website of the operator owning the PassengerJourney.
+
+    Booking:
+      allOf:
+        - $ref: '#/components/schemas/ConnectionMessage'
+      type: object
+      required:
+        - id
+        - status
+        - price
+      properties:
+        id:
+          $ref: '#/components/schemas/bookingId'
+        passengerPickupDate:
+          type: number
+          description: Passenger pickup datetime as a UNIX UTC timestamp in seconds.
+          format: long
+        passengerPickupLat:
+          type: "number"
+          format: "double"
+          description: Latitude of the passenger pick-up point.
+        passengerPickupLng:
+          type: "number"
+          format: "double"
+          description: Longitude of the passenger pick-up point.
+        passengerDropLat:
+          type: "number"
+          format: "double"
+          description: Latitude of the passenger drop-off point.
+        passengerDropLng:
+          type: "number"
+          format: "double"
+          description: Longitude of the passenger drop-off point.
+        passengerPickupAddress:
+          type: string
+          description: String representing the pickup-up address.
+        passengerDropAddress:
+          type: string
+          description: String representing the drop-off address.
+        status:
+          $ref: '#/components/schemas/bookingStatus'
+        duration:
+          type: integer
+          description: Carpooling duration in seconds.
+        distance:
+          type: integer
+          description: |
+            Carpooling distance in meters. When the booking is COMPLETED or VALIDATED, this is the actual distance travelled if available.
+        webUrl:
+          type: string
+          description: URL of the booking on the webservice provider platform.
+        price:
+          $ref: '#/components/schemas/Price'
+        car:
+          $ref: '#/components/schemas/Car'
+
+    bookingId:
+      type: string
+      description: Booking id is common between both operators, and must be set as a MD5 hashing of a string concatenating the `driverJourneyId`, the `passengerJourneyId` and a UNIX UTC timestamp in seconds.
+
+    bookingStatus:
+      type: string
+      description: Status of the booking.
+      enum:
+        - WAITING_CONFIRMATION
+        - CONFIRMED
+        - CANCELLED
+        - COMPLETED_PENDING_VALIDATION
+        - VALIDATED
+      default: WAITING_CONFIRMATION
 
   responses:
     BadRequest:

--- a/standard-covoiturage_openapi.yaml
+++ b/standard-covoiturage_openapi.yaml
@@ -244,7 +244,8 @@ paths:
                   maxLength: 255
                   description: ID of the journey to which the message is related (if any)
                 bookingId:
-                  $ref: '#/components/schemas/bookingId'
+                  allOf:
+                    - $ref: '#/components/schemas/bookingId'
                   description: ID of the booking to which the message is related (if any)
 
       responses:

--- a/standard-covoiturage_openapi.yaml
+++ b/standard-covoiturage_openapi.yaml
@@ -956,6 +956,8 @@ components:
       type: object
       required:
         - id
+        - driver
+        - passenger
         - status
         - price
         - passengerPickupDate
@@ -966,6 +968,10 @@ components:
       properties:
         id:
           $ref: '#/components/schemas/bookingId'
+        driver:
+          $ref: '#/components/schemas/UserId'
+        passenger:
+          $ref: '#/components/schemas/UserId'
         passengerPickupDate:
           type: number
           description: Passenger pickup datetime as a UNIX UTC timestamp in seconds.

--- a/standard-covoiturage_openapi.yaml
+++ b/standard-covoiturage_openapi.yaml
@@ -224,9 +224,9 @@ paths:
                 - recipientCarpoolerType
               properties:
                 from:
-                  $ref: '#/components/schemas/User'
+                  $ref: '#/components/schemas/UserId'
                 to:
-                  $ref: '#/components/schemas/User'
+                  $ref: '#/components/schemas/UserId'
                 message:
                   type: string
                   maxLength: 500
@@ -860,21 +860,10 @@ components:
           description: ISO 4217 code representing the currency of the price.
 
     User:
+      allOf:
+        - $ref: '#/components/schemas/UserId'
       type: object
-      required:
-        - id
-        - alias
-        - operatorWebUrl
       properties:
-        id:
-          type: string
-          description: User's identifier. It MUST be unique for a given `operatorWebUrl`.
-        operatorWebUrl:
-          type: string
-          description: Base URL of the website of the operator owning the DriverJourney.
-        alias:
-          type: string
-          description: User's alias.
         firstName:
           type: string
           description: User's first name.
@@ -900,6 +889,22 @@ components:
           type: boolean
           description: true if the identity of this user has been verified by the operator or a third party; and the firstName, lastName, birthdate have been confirmed as identitical to an official identity proof document. Can be left empty if the information is not available.
 
+    UserId:
+      type: object
+      required:
+        - id
+        - alias
+        - operator
+      properties:
+        id:
+          type: string
+          description: User's identifier. It MUST be unique for a given `operator`
+        operator:
+          type: string
+          description: The operator identifier. MUST be a Fully Qualified Domain Name (example carpool.mycity.com) owned by the operator or a Partially Qualified Domain Name (example operator.org) owned and exclusively operated by the operator. Operators SHOULD always send the same value.
+        alias:
+          type: string
+          description: User's alias
 
     Preferences:
       type: object

--- a/standard-covoiturage_openapi.yaml
+++ b/standard-covoiturage_openapi.yaml
@@ -234,9 +234,9 @@ paths:
                 recipientCarpoolerType:
                   type: string
                   enum:
-                    - driver
-                    - passenger
-                  default: driver
+                    - DRIVER
+                    - PASSENGER
+                  default: DRIVER
                   description: Defines if the recipient of this message is either the driver or the passenger.
                 journeyId:
                   type: string


### PR DESCRIPTION
This PR is the rebased version of #6.

Add specs for booking by API without switching platforms : POST/PATCH/GET booking.

Created another branch as I was afraid force pushing may lose some comments. 

# Edits (2nd attempt)

- Remove PUT /bookings/{BookingId} endpoint
- Transform Booking ID into UUID
- passengerPickup[Lat|Lng|Date] and passengerDrop[Lat|Lng] are mandatory in a Booking (cf [this comment](https://github.com/fabmob/standard-covoiturage/pull/6#discussion_r863604624))
- Changing the POST \messages endpoint slightly : 
  - `to` and `from` attributes with `UserId` objects.
  - `UserId` is a subset of `User` object (with `id`, `alias`, and added an `operator` field such as in #17)
  - Optional `journeyId` and `bookingId` reference with the message
- Optional `journeyId` on the Booking object.
- Added an optional `message` attribute to the PATCH endpoint, to be able to explain the status change, especially for cancellation.


<details>
  <summary>[Hidden] Details of the first try</summary>

About [my additions](https://github.com/fabmob/standard-covoiturage/pull/30/files/c353bc1661fb9845a81a5f78eb3dacf651fa3002..659753b52f174ecd5285d711dbd4476d1f8aa56f) :
- Remove PUT /bookings/{BookingId} endpoint
- Transform Booking ID into UUID
- Instead of repeating fields, I integrated `PassengerTrip` or `DriverTrip` + `JourneySchedule`. It makes sense to me to repeat this journey information, as the objective is to book a *journey*, and I was a bit bothered not to have e.g. driver information. In the spec, I plan to mention that validating a booking request is about agreeing on its required fields. As a follow-up : 
    - I put the journey `webUrl` outside of the `Trip` object as it should not be part of trip information (and had no sense in booking context)
    - I removed `passengerId` and `journeyId` : if all the information is repeated, having an ID is actually useless.
    - I removed the operator / maas urls, which where only needed to make the (ID, url) pair unique (from my understanding).
- Added a userIdToken for authentification, implying the use of MaaS Connect even for API booking.
- Added an optional `message` attribute to the PATCH endpoint, to be able to explain the status change, especially for cancellation. See below however, its relevance depends on if PATCH endpoint is used bidirectionnaly or not...
</details>

# Related questions

1. Information flow after the booking 

It is not clear to me if we would need asynchronous information push from the carsharing operator to the MaaS platform, but I think at least for status changes (e.g. cancellation !). I would suggest to have POST, GET /bookings endpoints only implemented by the carsharing operator, and I see two options : 
- either PATCH is implemented by both the MaaS platform and the carsharing operator.
- either PATCH is implemented by the carsharing operator and the latter uses the booking feed POST /booking_events like for booking by deep link.


<details>
  <summary>2. Agreement on price [RESOLVED]</summary>

(Initial comment [here](https://github.com/fabmob/standard-covoiturage/pull/6#discussion_r874568508)) 
In the search, the carsharing operator gives a price *estimate* (without knowing who is the passenger), and there are no more exchanges between carsharing operator and MaaS before the MaaS has to create a `Booking` object with definitive price. Will the MaaS always be able to determine the right price by itself with only this estimate ?
</details>

3. Exchange of user information

* I would suggest to agree on the minimal requirements to identify a user (e.g. `id` + `operator`) and use this everywhere, in conjunction with a GET /user endpoint. What do you think ?
* It also seems that the deeplink booking object is missing driver and passenger information.

4. `distance` attribute imutability

The definition of distance seems not consistent with the immutability of the booking object that has been decided. Their is currently no way to update this attribute with the "actual distance travelled" after the trip.
> Carpooling distance in meters. When the booking is COMPLETED or VALIDATED, this is the actual distance travelled if available.

5. Use POST /messages for deeplink ?

Any interest in sharing this endpoint for deeplink and API booking ?
