### PR TITLE
Add GET /api/info endpoint

### DIFF
--- a/standard-covoiturage_openapi.yaml
+++ b/standard-covoiturage_openapi.yaml
@@ -179,7 +179,7 @@ paths:
   /status:
     get:
       tags:
-      - status
+        - API information
       summary: Give health status of the webservice.
       responses:
         200:
@@ -188,6 +188,36 @@ paths:
           $ref: '#/components/responses/TooManyRequests'
         500:
           $ref: '#/components/responses/InternalServerError'
+
+  /api/info:
+     get:
+       tags:
+         - API information
+       summary: describes the running API implementation
+       description: Gives the version of the running API, and the available endpoints.
+       responses:
+         '200':
+           description: successful operation
+           content:
+             application/json:
+               schema:
+                   type: object
+                   required:
+                     - version
+                     - baseUrl
+                     - endpoints
+                   properties:
+                     version:
+                       type: string
+                       description: Version of the running API
+                     baseUrl:
+                       type: string
+                       description: base url of the API
+                     endpoints:
+                       type: array
+                       description: List of endpoints with their implementation status
+                       items:
+                         $ref: "#/components/schemas/Endpoint"
 
 #
 # Schemas
@@ -620,6 +650,34 @@ components:
         brand:
           type: string
           description: Brand of the car.
+
+    Endpoint:
+      type: object
+      description: a formal description of an endpoint.
+      required:
+        - method
+        - path
+        - status
+      properties:
+        method:
+          type: string
+          enum: [
+            POST,
+            PUT,
+            GET,
+            DELETE,
+            PATCH
+          ]
+        path:
+          description: the exact path of the endpoint, starting after the base URL
+          type: string
+          example: /bookings
+        status:
+          type: string
+          enum: [
+            NOT_IMPLEMENTED,
+            IMPLEMENTED
+          ]
 
   responses:
     BadRequest:


### PR DESCRIPTION
Closes #13. 
Self documentation of API version and available endpoints. 
Note: TOMP-API supports self documentation of ALL available versions (i.e. the carsharing operator might implement and offer several choices). This seems a bit overkill for me at this stage but if you think it makes sense, then I can change the endpoint to return information on each available version.