### PR TITLE
README.fr.md plus détaillé

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -130,7 +130,7 @@ Entrée d'API implémentée par la plateforme de MaaS :
 ## La réservation déléguée via redirection vers l'opérateur de covoiturage (deep link)
 
 La réservation déléguée par deep link est l'un des deux parcours pour la 
-réservation d'un trajet, dans laquelle l'utilisateur est redirigé vers 
+réservation d'un trajet, dans lequel l'utilisateur est redirigé vers 
 l'application de l'opérateur de covoiturage afin de réserver ses trajets.  
 L'opérateur de MaaS peut bénéficier d'un flux d'information concernant les 
 réservations qui sont effectuées. Pour cela, une authentification de 

--- a/README.fr.md
+++ b/README.fr.md
@@ -42,6 +42,108 @@ Les blocs fonctionnels couverts par l'API sont les suivants :
   (deep link)
 * Le flux d'information des réservations vers le MaaS
 
+Il y a donc deux parcours de réservation distincts, la réservation intégrée 
+**par API** et la réservation déléguée **par deep link**. L'opérateur de 
+covoiturage peut choisir d'implémenter l'un, l'autre, ou les deux parcours.
+
+# Détails par bloc fonctionnel
+
+## Recherche de trajets simples
+
+Le standard couvre la rercherche de trajets covoiturés en tant que passager ou 
+conducteur, d'une origine à une destination et à une date et heure données. La 
+réponse présente une liste de trajets potentiels, qui précisent notamment :
+
+* Les informations concernant le conducteur ou le passager, et le trajet
+* Le prix estimé pour le voyageur (cas deep link), ou le prix attendu par 
+  l'opérateur de covoiturage (cas réservation par API)
+* L'URL du deep link de réservation si la fonctionnalité est supportée
+
+Entrées d'API associées à cette fonctionnalité implémentées par l'opérateur de 
+covoiturage :
+
+* `GET /driver_journeys` et/ou
+* `GET /passenger_journeys`
+ 
+## Recherche de trajets réguliers
+
+Le standard permet également la recherche de trajets de covoiturage réguliers.  
+Contrairement aux trajets simples, la recherche ne précise pas une date 
+précise, mais une récurrence hebdomadaire spécifiée via une heure de la 
+journée, et les jours de la semaine souhaités.
+
+La réponse présente une liste de propositions, où chacune contient une liste 
+de trajets qui couvrent au moins partiellement les exigences de récurrence 
+spécifiées lors de la requête. Chacun de ces trajets peut être réservé 
+individuellement de la même manière qu'à la suite d'une recherche simple.
+
+Dans le cas de la réservation via deep link, afin d'éviter plusieurs 
+allers-retours entre les applicatifs du MaaS et de l'opérateur de covoiturage, 
+l'attribut `webUrl` permet de rediriger vers une page qui agrège les 
+différents trajets, par exemple la page du conducteur.
+
+Entrées d'API associées à cette fonctionnalité implémentées par l'opérateur de 
+covoiturage :
+
+* `GET /driver_regular_trips` et/ou
+* `GET /passenger_regular_trips`
+ 
+## Échange de messages entre usagers
+
+Le standard permet l'envoi de messages d'un utilisateur à un autre. De manière 
+factultative, le trajet ou la réservation auquel se réfère le message peut 
+être précisé.
+
+Entrée d'API associée à cette fonctionnalité implémentée par l'opérateur de 
+covoiturage et la plateforme de MaaS :
+
+* `POST /messages` 
+  
+
+## Réservation intégrée par API
+
+La réservation intégrée par API est l'un des deux parcours pour la réservation 
+d'un trajet. Elle ne nécessite pas d'authentification de l'usager auprès de 
+l'opérateur de covoiturage.  L'opérateur de MaaS peut demander la création 
+d'une réservation (entrée `POST` ci-dessous), de modifier le statut d'une 
+réservation (entrée `PATCH`) ou interroger l'opérateur de covoiturage sur les 
+informations relatives à une réservation (entrée `GET`).
+
+L'opérateur de covoiturage peut quant à lui symétriquement modifier le statut 
+d'une réservation, par exemple en cas d'annulation.
+
+Le prix renvoyé lors de la recherche est le prix attendu par la plateforme de 
+covoiturage. Le Maas est libre de fixer un prix différent à l'utilisateur 
+final.
+
+
+Entrées d'API implémentées par l'opérateur de covoiturage :
+
+* `POST /bookings`
+* `PATCH /bookings/{bookingId}`
+* `GET /bookings/{bookingId}`
+
+Entrée d'API implémentée par la plateforme de MaaS :
+
+* `PATCH /bookings/{bookingId}` 
+  
+## La réservation déléguée via redirection vers l'opérateur de covoiturage (deep link)
+
+La réservation déléguée par deep link est l'un des deux parcours pour la 
+réservation d'un trajet, dans laquelle l'utilisateur est redirigé vers 
+l'application de l'opérateur de covoiturage afin de réserver ses trajets.  
+L'opérateur de MaaS peut bénéficier d'un flux d'information concernant les 
+réservations qui sont effectuées. Pour cela, une authentification de 
+l'utilisateur via un dispositif basé sur OpenID Connect est nécessaire.
+
+L'URL du deep link de réservation est fourni à la plateforme de MaaS au moment 
+de la recherche.
+
+Entrée d'API implémentée par la plateforme de MaaS pour le flux d'informations 
+concernant les réservations via deep link :
+
+* `POST /booking_events`
+
 # Contact
 
 Pour toute question, contactez 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Introduction to the "standard covoiturage"
 
-Version française [disponible ici](./README.fr.md).
+:fr: Version française [disponible ici](./README.fr.md).
 
 This repository presents the work of the "standard covoiturage" ("carpoling 
 standard") working group. It brings together French carpooling and MaaS 


### PR DESCRIPTION
Ajout au README d'informations concernant les différents blocs fonctionnels du standard.

Pour l'instant uniquement dans la version française (README.fr.md, avec lien de redirection dans README.md), la traduction sera effectuée après validation du contenu.

