### PR TITLE
BookingId mandatory for Messages

### DIFF
--- a/standard-covoiturage_openapi.yaml
+++ b/standard-covoiturage_openapi.yaml
@@ -224,6 +224,7 @@ paths:
                 - to
                 - message
                 - recipientCarpoolerType
+                - bookingId
               properties:
                 from:
                   $ref: '#/components/schemas/User'
@@ -280,7 +281,15 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Booking'
+              type: object
+              allOf:
+                - $ref: '#/components/schemas/Booking'
+                - type: object
+                  properties:
+                    message:
+                      type: string
+                      maxLength: 500
+                      description: Free text content of a message. The message can contain all the details (phone number, email, etc.) allowing the recipient to call back the sender in order to carpool with him/her.
 
       responses:
         201:
@@ -1036,6 +1045,7 @@ components:
       type: string
       description: Status of the booking.
       enum:
+        - INITIATED
         - WAITING_CONFIRMATION
         - CONFIRMED
         - CANCELLED


### PR DESCRIPTION
While implementing the full API booking flow, we found out hard and counter-intuitive to leave open the sending of messages WITHOUT a Booking context.
As a consequence, we propose to : 
1. force to have all messages attached to Booking context (`bookingId` required in `POST /messages`) ;
2. enable the sending of messages while creating a Booking (`message` optional attribute added in `POST /bookings` as it is already available in the `PATCH /bookings` endpoint) ;
3. add an `INITIATED` bookingStatus (this `bookingStatus` is just used in the full API booking flow) to differenciate booking started just a casual chat and a formal booking request made by the passenger to the driver.