### PR TITLE
Resolve ambiguity on "Waiting confirmation" booking status for booking by API

### DIFF
--- a/standard-covoiturage_openapi.yaml
+++ b/standard-covoiturage_openapi.yaml
@@ -274,7 +274,7 @@ paths:
       tags:
       - Interact
       summary: Create a punctual outward Booking request.
-      description: Route used to synchronize a Booking request initiated by a platform to the second platform involved in the shared punctual outward journey. While posting a new Booking, its status must always be set first as `status=WAITING_CONFIRMATION`. _Reminder:_ In case of booking without deeplink, the sender platform MUST also store the Booking object, and be ready to receive modifications of it through the PATCH /bookings API endpoint.
+      description: Route used to synchronize a Booking request initiated by a platform to the second platform involved in the shared punctual outward journey. While posting a new Booking, its status must always be set first as `status=WAITING_PASSENGER_CONFIRMATION` or `status=WAITING_DRIVER_CONFIRMATION`. _Reminder:_ In case of booking without deeplink, the sender platform MUST also store the Booking object, and be ready to receive modifications of it through the PATCH /bookings API endpoint.
       operationId: postBookings
       requestBody:
         content:
@@ -1036,12 +1036,13 @@ components:
       type: string
       description: Status of the booking.
       enum:
-        - WAITING_CONFIRMATION
+        - WAITING_DRIVER_CONFIRMATION
+        - WAITING_PASSENGER_CONFIRMATION
         - CONFIRMED
         - CANCELLED
         - COMPLETED_PENDING_VALIDATION
         - VALIDATED
-      default: WAITING_CONFIRMATION
+      default: WAITING_PASSENGER_CONFIRMATION
 
   responses:
     BadRequest:


### PR DESCRIPTION
Booking requests have a status to describe the state in the workflow of the booking. The first (or second after PR https://github.com/fabmob/standard-covoiturage/pull/50) status in the workflow is WAITING_CONFIRMATION.

We faced an issue with this while implementing bidirectional interoperability.

In the case of a bidirectional interoperability between a MaaS and a carpool operator (a user from the MaaS can book a journey from the operator, and a user from the operator can book a journey from the MaaS), the WAITING_CONFIRMATION state is ambiguous. By reading the booking status, we cannot tell if we are waiting for a confirmation from the MaaS or from the operator, as it doesn't specify if we are waiting for a response from the driver or the passenger.

The introduction of a booking status INITIATED proposed in PR https://github.com/fabmob/standard-covoiturage/pull/50 makes it problematic even in the case of a "one way" relationship between the MaaS and the operator (only initiate booking from the MaaS to a journey on the operator, and not the other way), as : 

- The MaaS could create a booking to set a status as INITIATED first, to send a message
- Both the operator or the Maas could patch the status to WAITING_CONFIRMATION

In this case, it will also be ambiguous and we won't know by reading the booking state which platform/user has to confirm

To resolve this ambiguity, we propose to : 

- Remove WAITING_CONFIRMATION in the bookingStatus enum
- Replace it with unambiguous "WAITING_DRIVER_CONFIRMATION" and "WAITING_PASSENGER_CONFIRMATION"